### PR TITLE
Create pythonpublish.yml

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -1,0 +1,26 @@
+name: Upload Python Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python setup.py sdist
+        twine upload --repository-url https://test.pypi.org/legacy/ dist/*


### PR DESCRIPTION
This should publish to the PyPI test server upon release creation. I'm choosing to automatically deploy to the test server because PyPI doesn't let you change an upload if something goes wrong.

To test that the deployment was successful use:

```sh
pip install -i https://test.pypi.org/simple/ cooltools
```