### PR TITLE
Saddle Modifications

### DIFF
--- a/cooltools/cli/compute_saddle.py
+++ b/cooltools/cli/compute_saddle.py
@@ -363,7 +363,7 @@ def compute_saddle(
             qlo, qhi = qrange
         else:
             qlo, qhi = 0.0, 1.0
-        q_edges = np.linspace(qlo, qhi, n_bins)
+        q_edges = np.linspace(qlo, qhi, n_bins+1)
         binedges = saddle.quantile(track[track_name], q_edges)
     else:
         if len(range_):
@@ -372,7 +372,7 @@ def compute_saddle(
             lo, hi = saddle.quantile(track[track_name], qrange)
         else:
             lo, hi = track[track_name].min(), track[track_name].max()
-        binedges = np.linspace(lo, hi, n_bins)
+        binedges = np.linspace(lo, hi, n_bins+1)
 
     digitized, hist = saddle.digitize_track(
         binedges, track=(track, track_name), regions=track_chroms

--- a/cooltools/saddle.py
+++ b/cooltools/saddle.py
@@ -103,9 +103,8 @@ def digitize_track(binedges, track, regions=None):
     # subset and re-order chromosome groups
     if regions is not None:
         regions = [bioframe.parse_region(reg) for reg in regions]
-        grouped = track.groupby("chrom")
         track = pd.concat(
-            bioframe.bedslice(grouped, chrom, st, end) for (chrom, st, end) in regions
+            bioframe.bedslice(track, region) for region in regions
         )
 
     # histogram the signal
@@ -249,7 +248,7 @@ def make_saddle(
     regions=None,
     min_diag=3,
     max_diag=-1,
-    trim_outliers=False,
+    trim_outliers=True,
     verbose=False,
 ):
     """
@@ -306,11 +305,9 @@ def make_saddle(
         regions = [bioframe.parse_region(reg) for reg in regions]
 
     digitized_tracks = {
-        reg: bioframe.bedslice(digitized_df.groupby("chrom"), reg[0], reg[1], reg[2])[
-            name
-        ]
-        for reg in regions
-    }
+                        region: bioframe.bedslice(digitized_df, region)[name]
+                        for region in regions
+                       }
 
     if contact_type == "cis":
         supports = list(zip(regions, regions))


### PR DESCRIPTION
Making some fixes to saddle.py to working with latest bioframe. Also, suggesting some changes to compute_saddle CLI:

1) Make the default option of the CLI input to be quantiles since this the recommended "best practice." https://github.com/mirnylab/cooltools/blob/980e5829499e726dc5a9e950986c03b88e831d8a/cooltools/cli/compute_saddle.py#L65-L69

2) The number of bins used to make binedges must be n_bins+1 and not n_bins. https://github.com/mirnylab/cooltools/blob/980e5829499e726dc5a9e950986c03b88e831d8a/cooltools/cli/compute_saddle.py#L366 https://github.com/mirnylab/cooltools/blob/980e5829499e726dc5a9e950986c03b88e831d8a/cooltools/cli/compute_saddle.py#L375

3) Add a CLI option for trimming outliers when returning and plotting the saddleplot. Currently none exists.

4) Expected's default output ignores the first two diags. The min-dist kwarg in make_saddle.py can hypothetically be less than this. https://github.com/mirnylab/cooltools/blob/980e5829499e726dc5a9e950986c03b88e831d8a/cooltools/cli/compute_saddle.py#L42-L49 It doesn't break the code or change the result as all NaN bins are ignored in the aggregation but it's technically not the result the user would ask for. Perhaps we should raise a warning if such a situation arises?

Additionally I suggest that we make trim_outliers=True be the default in saddle.py. https://github.com/mirnylab/cooltools/blob/980e5829499e726dc5a9e950986c03b88e831d8a/cooltools/saddle.py#L252 It seems strange to ask for n bins but then get back n+2 unless it's specifically asked for. 
