### PR TITLE
fix trans saddles a bit, add trans tests

### DIFF
--- a/cooltools/eigdecomp.py
+++ b/cooltools/eigdecomp.py
@@ -266,7 +266,6 @@ def trans_eig(
     A[:, is_bad_bin] = 0
 
     # Fake cis and re-balance
-    A = numutils.iterative_correction_symmetric(A)[0]
     A = _fake_cis(A, ~is_trans)
     A = numutils.iterative_correction_symmetric(A)[0]
     A = _fake_cis(A, ~is_trans)

--- a/cooltools/saddle.py
+++ b/cooltools/saddle.py
@@ -120,7 +120,7 @@ def digitize_track(binedges, track, regions=None):
 
 def make_cis_obsexp_fetcher(clr, expected, weight_name="weight"):
     """
-    Construct a function that returns intra-chromosomal OBS/EXP.
+    Construct a function that returns intra-chromosomal OBS/EXP for symmetrical regions.
 
     Parameters
     ----------
@@ -128,17 +128,17 @@ def make_cis_obsexp_fetcher(clr, expected, weight_name="weight"):
         Observed matrix.
     expected : tuple of (DataFrame, str)
         Diagonal summary statistics for each chromosome, and name of the column
-        to use
+        with the values of expected to use.
     weight_name : str
         Name of the column in the clr.bins to use as balancing weights
 
     Returns
     -------
-    getexpected(chrom, _). 2nd arg is ignored.
+    getexpected(reg, _). 2nd arg is ignored.
 
     """
-    expected, name = expected
-    expected = {k: x.values for k, x in expected.groupby("region")[name]}
+    expected, expected_name = expected
+    expected = {k: x.values for k, x in expected.groupby("region")[expected_name]}
 
     def _fetch_cis_oe(reg1, reg2):
         obs_mat = clr.matrix(balance=weight_name).fetch(reg1)
@@ -159,8 +159,8 @@ def make_trans_obsexp_fetcher(clr, expected, weight_name="weight"):
     expected : (DataFrame, name) or scalar
         Average trans values. If a scalar, it is assumed to be a global trans
         expected value. If a tuple of (dataframe, name), the dataframe must
-        have a MultiIndex with 'chrom1' and 'chrom2' and must also have a column
-        labeled ``name``.
+        have a MultiIndex with 'region1' and 'region2' and must also have a column
+        labeled ``name``, with the values of expected.
     weight_name : str
         Name of the column in the clr.bins to use as balancing weights
 
@@ -176,27 +176,27 @@ def make_trans_obsexp_fetcher(clr, expected, weight_name="weight"):
         )
 
     elif isinstance(expected, (tuple, list)):
-        expected, name = expected
+        expected, expected_name = expected
 
-        if not name:
+        if not expected_name:
             raise ValueError("Name of data column not provided.")
 
         expected = {
-            k: x.values for k, x in expected.groupby(["chrom1", "chrom2"])[name]
+            k: x.values for k, x in expected.groupby(["region1", "region2"])[expected_name]
         }
 
-        def _fetch_trans_exp(chrom1, chrom2):
-            # Handle chrom flipping
-            if (chrom1, chrom2) in expected.keys():
-                return expected[chrom1, chrom2]
-            elif (chrom2, chrom1) in expected.keys():
-                return expected[chrom2, chrom1]
-            # .loc is the right way to get [chrom1,chrom2] value from MultiIndex df:
+        def _fetch_trans_exp(region1, region2):
+            # Handle region flipping
+            if (region1, region2) in expected.keys():
+                return expected[region1, region2]
+            elif (region2, region1) in expected.keys():
+                return expected[region2, region1]
+            # .loc is the right way to get [region1,region2] value from MultiIndex df:
             # https://pandas.pydata.org/pandas-docs/stable/advanced.html#advanced-indexing-with-hierarchical-index
             else:
                 raise KeyError(
                     "trans-exp index is missing a pair of chromosomes: "
-                    "{}, {}".format(chrom1, chrom2)
+                    "{}, {}".format(region1, region2)
                 )
 
         def _fetch_trans_oe(reg1, reg2):

--- a/tests/test_compartments_saddle.py
+++ b/tests/test_compartments_saddle.py
@@ -149,7 +149,7 @@ def test_trans_saddle_cli(request, tmpdir):
             "--n-bins", "30",
             "--scale", "log",
             in_cool,
-            f"{out_eig_prefix}.trans.vecs.tsv::E3", # 3rd EV stores checkerboard
+            f"{out_eig_prefix}.trans.vecs.tsv::E3",  # 3rd EV stores checkerboard
             out_expected
         ]
     )

--- a/tests/test_compartments_saddle.py
+++ b/tests/test_compartments_saddle.py
@@ -106,7 +106,7 @@ def test_trans_compartment_cli(request, tmpdir):
     test_trans_eigs = pd.read_table(out_eig_prefix + ".trans.vecs.tsv", sep="\t")
     r = np.abs(
         np.corrcoef(
-            test_trans_eigs.E3.values, np.sin(test_trans_eigs.start * 2 * np.pi / 500)
+            test_trans_eigs.E1.values, np.sin(test_trans_eigs.start * 2 * np.pi / 500)
         )[0, 1]
     )
     assert r > 0.95
@@ -149,7 +149,7 @@ def test_trans_saddle_cli(request, tmpdir):
             "--n-bins", "30",
             "--scale", "log",
             in_cool,
-            f"{out_eig_prefix}.trans.vecs.tsv::E3",  # 3rd EV stores checkerboard
+            f"{out_eig_prefix}.trans.vecs.tsv",
             out_expected
         ]
     )

--- a/tests/test_compartments_saddle.py
+++ b/tests/test_compartments_saddle.py
@@ -88,6 +88,88 @@ def test_saddle_cli(request, tmpdir):
     assert cc > 0.9
 
 
+def test_trans_compartment_cli(request, tmpdir):
+    # somehow - it is E3 that captures sin-like plaid
+    # pattern, instead of E1 - we'll keep it like that for now:
+    in_cool = op.join(request.fspath.dirname, "data/sin_eigs_mat.cool")
+    out_eig_prefix = op.join(tmpdir, "test.eigs")
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, [
+            'call-compartments',
+            '--contact-type', "trans",
+            '-o', out_eig_prefix,
+            in_cool,
+        ]
+    )
+    assert result.exit_code == 0
+    test_trans_eigs = pd.read_table(out_eig_prefix + ".trans.vecs.tsv", sep="\t")
+    r = np.abs(
+        np.corrcoef(
+            test_trans_eigs.E3.values, np.sin(test_trans_eigs.start * 2 * np.pi / 500)
+        )[0, 1]
+    )
+    assert r > 0.95
+
+
+def test_trans_saddle_cli(request, tmpdir):
+    in_cool = op.join(request.fspath.dirname, "data/sin_eigs_mat.cool")
+    out_eig_prefix = op.join(tmpdir, "test.eigs")
+    out_expected = op.join(tmpdir, "test.trans.expected")
+    out_saddle_prefix = op.join(tmpdir, "test.trans.saddle")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, [
+            'call-compartments',
+            '--contact-type', "trans",
+            '-o', out_eig_prefix,
+            in_cool
+        ]
+    )
+    assert result.exit_code == 0
+
+    try:
+        subprocess.check_output(
+            f"python -m cooltools compute-expected --contact-type trans {in_cool} > {out_expected}",
+            shell=True,
+        ).decode("ascii")
+    except subprocess.CalledProcessError as e:
+        print(e.output)
+        print(sys.exc_info())
+        raise e
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, [
+            "compute-saddle",
+            "-o", out_saddle_prefix,
+            "--contact-type", "trans",
+            "--range", "-0.5", "0.5",
+            "--n-bins", "30",
+            "--scale", "log",
+            in_cool,
+            f"{out_eig_prefix}.trans.vecs.tsv::E3", # 3rd EV stores checkerboard
+            out_expected
+        ]
+    )
+    assert result.exit_code == 0
+
+    log2_sad = np.log2(np.load(out_saddle_prefix + ".saddledump.npz")["saddledata"])
+    bins = np.load(out_saddle_prefix + ".saddledump.npz")["binedges"]
+    binmids = (bins[:-1] + bins[1:]) / 2
+    log2_theor_sad = np.log2(1 + binmids[None, :] * binmids[:, None])
+
+    log2_sad_flat = log2_sad[1:-1, 1:-1].flatten()
+    log2_theor_sad_flat = log2_theor_sad.flatten()
+
+    mask = np.isfinite(log2_sad_flat) & np.isfinite(log2_theor_sad_flat)
+
+    cc = np.abs(np.corrcoef(log2_sad_flat[mask], log2_theor_sad_flat[mask])[0][1])
+
+    assert cc > 0.9
+
+
 # def test_digitize_track(request):
 #     pass
 


### PR DESCRIPTION
saddles were broken for `--contact-type trans` - and this PR is a quick fix for that
also added a couple of trans related tests - compartment and saddle CLI , in order to make sure trans-business isn't neglected going forward - WE NEED MOAR TESTS !

also updated some docstrings -because it took me awhile to understand what's written in there ... and some vriable names as well for the same reason - less confusion , better maintenance !