### PR TITLE
Fix fake_cis sampling bug

### DIFF
--- a/cooltools/eigdecomp.py
+++ b/cooltools/eigdecomp.py
@@ -165,7 +165,7 @@ def _filter_heatmap(A, transmask, perc_top, perc_bottom):
 
 
 def _fake_cis(A, cismask):
-    cismask = cismask.astype(np.int64)
+    cismask = cismask.astype(np.uint8)
     s = np.abs(np.sum(A, axis=0)) <= 1e-10
     cismask[:, s] = 2
     cismask[s, :] = 2


### PR DESCRIPTION
Missing break statement caused `fake_cis` to only sample from the same row, but not the same column.

Also changed the mask dtype to `uint8` to conserve space.