### PR TITLE
bugfix(snipping): features with empty regions return snips filled with NaNs

### DIFF
--- a/cooltools/snipping.py
+++ b/cooltools/snipping.py
@@ -134,15 +134,12 @@ def assign_regions(features, supports):
 
 def _pileup(data_select, data_snip, arg):
     support, feature_group = arg
-
     # check if region is annotated
     if pd.isnull(support):
-        lo = feature_group["lo"].values
-        hi = feature_group["hi"].values
-        s = hi-lo
-        stack = list(map(np.empty, zip(s, s)))
-        stack = np.dstack(stack)
-        stack[:] = np.nan
+        lo = feature_group["lo"].values[0]
+        hi = feature_group["hi"].values[0]
+        s = hi-lo # Shape of individual snip
+        stack = np.full((s, s, len(feature_group)), np.nan)
         # return empty snippets if region is not annotated
         return stack, feature_group["_rank"].values
 
@@ -202,7 +199,8 @@ def pileup(features, data_select, data_snip, map=map):
     cumul_stack, orig_rank = zip(
         *map(
             partial(_pileup, data_select, data_snip),
-            features.groupby("region", sort=False),
+            # Note that unannotated regions are NaNs and will be treated as a separate group
+            features.groupby("region", sort=False, dropna=False),
         )
     )
 

--- a/cooltools/snipping.py
+++ b/cooltools/snipping.py
@@ -136,7 +136,7 @@ def _pileup(data_select, data_snip, arg):
     support, feature_group = arg
     
     # check if region is unannotated
-    if len(support)==0:
+    if len(support) == 0:
         lo = feature_group["lo"].values[0]
         hi = feature_group["hi"].values[0]
         s = hi-lo # Shape of individual snip

--- a/cooltools/snipping.py
+++ b/cooltools/snipping.py
@@ -134,6 +134,18 @@ def assign_regions(features, supports):
 
 def _pileup(data_select, data_snip, arg):
     support, feature_group = arg
+
+    # check if region is annotated
+    if pd.isnull(support):
+        lo = feature_group["lo"].values
+        hi = feature_group["hi"].values
+        s = hi-lo
+        stack = list(map(np.empty, zip(s, s)))
+        stack = np.dstack(stack)
+        stack[:] = np.nan
+        # return empty snippets if region is not annotated
+        return stack, feature_group["_rank"].values
+
     # check if support region is on- or off-diagonal
     if len(support) == 2:
         region1, region2 = map(bioframe.region.parse_region_string, support)

--- a/cooltools/snipping.py
+++ b/cooltools/snipping.py
@@ -134,8 +134,9 @@ def assign_regions(features, supports):
 
 def _pileup(data_select, data_snip, arg):
     support, feature_group = arg
-    # check if region is annotated
-    if pd.isnull(support):
+    
+    # check if region is unannotated
+    if len(support)==0:
         lo = feature_group["lo"].values[0]
         hi = feature_group["hi"].values[0]
         s = hi-lo # Shape of individual snip
@@ -192,6 +193,7 @@ def pileup(features, data_select, data_snip, map=map):
         warnings.warn("Some features do not have regions assigned! Some snips will be empty.")
 
     features = features.copy()
+    features['region'] = features.region.fillna('') # fill in unanotated regions with empty string
     features["_rank"] = range(len(features))
 
     # cumul_stack = []
@@ -199,8 +201,8 @@ def pileup(features, data_select, data_snip, map=map):
     cumul_stack, orig_rank = zip(
         *map(
             partial(_pileup, data_select, data_snip),
-            # Note that unannotated regions are NaNs and will be treated as a separate group
-            features.groupby("region", sort=False, dropna=False),
+            # Note that unannotated regions will form a separate group
+            features.groupby("region", sort=False),
         )
     )
 

--- a/tests/test_snipping.py
+++ b/tests/test_snipping.py
@@ -4,6 +4,7 @@ import os.path as op
 import cooltools.snipping
 import numpy as np
 
+
 def test_snipper(request):
     """
     Test the snipping on matrix:
@@ -14,37 +15,27 @@ def test_snipper(request):
     regions = [(chrom, 0, clr.chromsizes[chrom]) for chrom in clr.chromnames]
 
     # Example region with windows, two regions from annotated genomic regions:
-    windows = cooltools.snipping.make_bin_aligned_windows(1_000_000,
-                                                        ['chr10', 'chr10'],
-                                                        [10_000_000, 20_000_000],
-                                                        flank_bp=2_000_000)
-    
+    windows = cooltools.snipping.make_bin_aligned_windows(
+        1_000_000, ["chr10", "chr10"], [10_000_000, 20_000_000], flank_bp=2_000_000
+    )
+
     windows = cooltools.snipping.assign_regions(windows, regions).reset_index(drop=True)
 
     snipper = cooltools.snipping.CoolerSnipper(clr)
-    stack = cooltools.snipping.pileup(
-            windows,
-            snipper.select,
-            snipper.snip,
-            map=map)
+    stack = cooltools.snipping.pileup(windows, snipper.select, snipper.snip, map=map)
 
     # Check that the size of snips is OK and there are two of them:
     assert stack.shape == (5, 5, 2)
 
     # Example region with windows, second window comes from unannotated genomic region:
-    windows = cooltools.snipping.make_bin_aligned_windows(1_000_000,
-                                                        ['chr10', 'chr10'],
-                                                        [10_000_000, 150_000_000],
-                                                        flank_bp=2_000_000)
-    
+    windows = cooltools.snipping.make_bin_aligned_windows(
+        1_000_000, ["chr10", "chr10"], [10_000_000, 150_000_000], flank_bp=2_000_000
+    )
+
     windows = cooltools.snipping.assign_regions(windows, regions).reset_index(drop=True)
 
     snipper = cooltools.snipping.CoolerSnipper(clr)
-    stack = cooltools.snipping.pileup(
-            windows,
-            snipper.select,
-            snipper.snip,
-            map=map)
+    stack = cooltools.snipping.pileup(windows, snipper.select, snipper.snip, map=map)
 
     assert stack.shape == (5, 5, 2)
     assert np.all(np.isfinite(stack[:, :, 0]))

--- a/tests/test_snipping.py
+++ b/tests/test_snipping.py
@@ -1,0 +1,51 @@
+import cooler
+import os.path as op
+
+import cooler
+import os.path as op
+
+import cooltools.snipping
+import numpy as np
+
+def test_snipper(request):
+    # Read cool file and create regions out of it:
+    clr = cooler.Cooler(op.join(request.fspath.dirname, "data/CN.mm9.1000kb.cool"))
+
+    regions = [(chrom, 0, clr.chromsizes[chrom]) for chrom in clr.chromnames]
+
+    # Example region with windows, two regions from annotated genomic regions:
+    windows = cooltools.snipping.make_bin_aligned_windows(
+            1_000_000, 
+            ['chr10', 'chr10'], 
+            [10_000_000, 20_000_000],
+            flank_bp=2_000_000)
+    windows = cooltools.snipping.assign_regions(windows, regions).reset_index(drop=True)
+
+    snipper = cooltools.snipping.CoolerSnipper(clr)
+    stack = cooltools.snipping.pileup(
+            windows,
+            snipper.select,
+            snipper.snip,
+            map=map)
+
+    # Check that the size of snips is OK and there are two of them:
+    assert stack.shape==(5, 5, 2)
+
+    # Example region with windows, second window comes from unannotated genomic region:
+    windows = cooltools.snipping.make_bin_aligned_windows(
+            1_000_000, 
+            ['chr10', 'chr10'], 
+            [10_000_000, 150_000_000],
+            flank_bp=2_000_000)
+    windows = cooltools.snipping.assign_regions(windows, regions).reset_index(drop=True)
+
+    snipper = cooltools.snipping.CoolerSnipper(clr)
+    stack = cooltools.snipping.pileup(
+            windows,
+            snipper.select,
+            snipper.snip,
+            map=map)
+
+    assert stack.shape==(5, 5, 2)
+    assert np.all(np.isfinite(stack[:, :, 0]))
+    assert np.all(np.isnan(stack[:, :, 1]))

--- a/tests/test_snipping.py
+++ b/tests/test_snipping.py
@@ -1,24 +1,24 @@
 import cooler
 import os.path as op
 
-import cooler
-import os.path as op
-
 import cooltools.snipping
 import numpy as np
 
 def test_snipper(request):
+    """
+    Test the snipping on matrix:
+    """
     # Read cool file and create regions out of it:
     clr = cooler.Cooler(op.join(request.fspath.dirname, "data/CN.mm9.1000kb.cool"))
 
     regions = [(chrom, 0, clr.chromsizes[chrom]) for chrom in clr.chromnames]
 
     # Example region with windows, two regions from annotated genomic regions:
-    windows = cooltools.snipping.make_bin_aligned_windows(
-            1_000_000, 
-            ['chr10', 'chr10'], 
-            [10_000_000, 20_000_000],
-            flank_bp=2_000_000)
+    windows = cooltools.snipping.make_bin_aligned_windows(1_000_000,
+                                                        ['chr10', 'chr10'],
+                                                        [10_000_000, 20_000_000],
+                                                        flank_bp=2_000_000)
+    
     windows = cooltools.snipping.assign_regions(windows, regions).reset_index(drop=True)
 
     snipper = cooltools.snipping.CoolerSnipper(clr)
@@ -29,14 +29,14 @@ def test_snipper(request):
             map=map)
 
     # Check that the size of snips is OK and there are two of them:
-    assert stack.shape==(5, 5, 2)
+    assert stack.shape == (5, 5, 2)
 
     # Example region with windows, second window comes from unannotated genomic region:
-    windows = cooltools.snipping.make_bin_aligned_windows(
-            1_000_000, 
-            ['chr10', 'chr10'], 
-            [10_000_000, 150_000_000],
-            flank_bp=2_000_000)
+    windows = cooltools.snipping.make_bin_aligned_windows(1_000_000,
+                                                        ['chr10', 'chr10'],
+                                                        [10_000_000, 150_000_000],
+                                                        flank_bp=2_000_000)
+    
     windows = cooltools.snipping.assign_regions(windows, regions).reset_index(drop=True)
 
     snipper = cooltools.snipping.CoolerSnipper(clr)
@@ -46,6 +46,6 @@ def test_snipper(request):
             snipper.snip,
             map=map)
 
-    assert stack.shape==(5, 5, 2)
+    assert stack.shape == (5, 5, 2)
     assert np.all(np.isfinite(stack[:, :, 0]))
     assert np.all(np.isnan(stack[:, :, 1]))


### PR DESCRIPTION
Related to https://github.com/open2c/cooltools/commit/1a637919bc8c1f2bee31a605491fb7d75fb65221
which turned out to be not a complete fix.