### PR TITLE
Rename regions to view everywhere

### DIFF
--- a/cooltools/cli/call_compartments.py
+++ b/cooltools/cli/call_compartments.py
@@ -160,38 +160,38 @@ def call_compartments(
         track = clr.bins()[["chrom", "start", "end"]][:]
         track_name = None
 
-    # define regions for cis compartment-calling
-    # use input "regions" BED file or all chromosomes mentioned in "track":
+    # define view for cis compartment-calling
+    # use input "view" BED file or all chromosomes mentioned in "track":
     if view is None:
         # Generate viewframe from clr.chromsizes:
-        regions_df = bioframe.make_viewframe(
+        view_df = bioframe.make_viewframe(
             [(chrom, 0, clr.chromsizes[chrom]) for chrom in clr.chromnames]
         )
     else:
         # Make viewframe out of table:
-        # Read regions dataframe:
+        # Read view_df:
         try:
-            regions_df = bioframe.read_table(view, schema="bed4", index_col=False)
+            view_df = bioframe.read_table(view, schema="bed4", index_col=False)
         except Exception:
-            regions_df = bioframe.read_table(view, schema="bed3", index_col=False)
-        # Convert regions dataframe to viewframe:
+            view_df = bioframe.read_table(view, schema="bed3", index_col=False)
+        # Convert view_df to viewframe:
         try:
-            regions_df = bioframe.make_viewframe(
-                regions_df, check_bounds=clr.chromsizes
+            view_df = bioframe.make_viewframe(
+                view_df, check_bounds=clr.chromsizes
             )
         except ValueError as e:
             raise RuntimeError(
                 "View table is incorrect, please, comply with the format. "
             ) from e
 
-    # TODO: Add check that regions_df has the same bins as track
+    # TODO: Add check that view_df has the same bins as track
 
     # it's contact_type dependent:
     if contact_type == "cis":
         eigvals, eigvec_table = eigdecomp.cooler_cis_eig(
             clr=clr,
             bins=track,
-            regions=regions_df,
+            view_df=view_df,
             n_eigs=n_eigs,
             phasing_track_col=track_name,
             clip_percentile=99.9,

--- a/cooltools/cli/compute_expected.py
+++ b/cooltools/cli/compute_expected.py
@@ -130,20 +130,20 @@ def compute_expected(
     clr = cooler.Cooler(cool_path)
     if view is None:
         # Generate viewframe from clr.chromsizes:
-        regions_df = bioframe.make_viewframe(
+        view_df = bioframe.make_viewframe(
             [(chrom, 0, clr.chromsizes[chrom]) for chrom in clr.chromnames]
         )
     else:
         # Make viewframe out of table:
-        # Read regions dataframe:
+        # Read view_df dataframe:
         try:
-            regions_df = bioframe.read_table(view, schema="bed4", index_col=False)
+            view_df = bioframe.read_table(view, schema="bed4", index_col=False)
         except Exception:
-            regions_df = bioframe.read_table(view, schema="bed3", index_col=False)
-        # Convert regions dataframe to viewframe:
+            view_df = bioframe.read_table(view, schema="bed3", index_col=False)
+        # Convert view dataframe to viewframe:
         try:
-            regions_df = bioframe.make_viewframe(
-                regions_df, check_bounds=clr.chromsizes
+            view_df = bioframe.make_viewframe(
+                view_df, check_bounds=clr.chromsizes
             )
         except ValueError as e:
             raise RuntimeError(
@@ -172,7 +172,7 @@ def compute_expected(
         if contact_type == "cis":
             result = expected.diagsum(
                 clr,
-                regions_df,
+                view_df,
                 transforms=transforms,
                 weight_name=weight_name,
                 bad_bins=None,
@@ -182,7 +182,7 @@ def compute_expected(
             )
         elif contact_type == "trans":
             # prepare pairwise combinations of regions for trans-expected (blocksum):
-            regions_pairwise = combinations(regions_df.itertuples(index=False), 2)
+            regions_pairwise = combinations(view_df.itertuples(index=False), 2)
             regions1, regions2 = zip(*regions_pairwise)
             result = expected.blocksum_asymm(
                 clr,

--- a/cooltools/dotfinder.py
+++ b/cooltools/dotfinder.py
@@ -491,7 +491,7 @@ def square_matrix_tiling(start, stop, step, edge, square=False, verbose=False):
             yield (lwx + start, rwx + start), (lwy + start, rwy + start)
 
 
-def heatmap_tiles_generator_diag(clr, regions, pad_size, tile_size, band_to_cover):
+def heatmap_tiles_generator_diag(clr, view_df, pad_size, tile_size, band_to_cover):
     """
     A generator yielding heatmap tiles that are needed to cover the requested
     band_to_cover around diagonal. Each tile is "padded" with pad_size edge to
@@ -501,8 +501,8 @@ def heatmap_tiles_generator_diag(clr, regions, pad_size, tile_size, band_to_cove
     ----------
     clr : cooler
         Cooler object to use to extract chromosome extents.
-    regions : pd.DataFrame
-        Dataframe of genomic regions to process, chrom, start, end, name.
+    view_df : viewframe
+        Viewframe with genomic regions to process, chrom, start, end, name.
     pad_size : int
         Size of padding around each tile. Typically the outer size of the
         kernel.
@@ -520,7 +520,7 @@ def heatmap_tiles_generator_diag(clr, regions, pad_size, tile_size, band_to_cove
 
     """
 
-    for chrom, start, end, region_name in regions.itertuples(index=False):
+    for chrom, start, end, region_name in view_df.itertuples(index=False):
         region_begin, region_end = clr.extent((chrom,start,end))
         for tilei, tilej in square_matrix_tiling(
             region_begin, region_end, tile_size, pad_size

--- a/tests/test_snipping.py
+++ b/tests/test_snipping.py
@@ -11,24 +11,24 @@ def test_ondiag_pileups_with_expected(request):
     """
     Test the snipping on matrix:
     """
-    # Read cool file and create regions out of it:
+    # Read cool file and create view_df out of it:
     clr = cooler.Cooler(op.join(request.fspath.dirname, "data/CN.mm9.1000kb.cool"))
     exp = pd.read_table(op.join(request.fspath.dirname, "data/CN.mm9.toy_expected.tsv"))
-    regions = bioframe.read_table(
+    view_df = bioframe.read_table(
         op.join(request.fspath.dirname, "data/CN.mm9.toy_regions.bed"), schema="bed4"
     )
     for snipper_class in (
         cooltools.snipping.ObsExpSnipper,
         cooltools.snipping.ExpectedSnipper,
     ):
-        snipper = snipper_class(clr, exp, regions=regions)
+        snipper = snipper_class(clr, exp, view_df=view_df)
 
         # I.
         # Example region with windows, two regions from annotated genomic regions:
         windows = cooltools.snipping.make_bin_aligned_windows(
             1_000_000, ["chr1", "chr1"], [102_000_000, 105_000_000], flank_bp=2_000_000
         )
-        windows = cooltools.snipping.assign_regions(windows, regions).reset_index(
+        windows = cooltools.snipping.assign_regions(windows, view_df).reset_index(
             drop=True
         )
         stack = cooltools.snipping.pileup(
@@ -43,7 +43,7 @@ def test_ondiag_pileups_with_expected(request):
         windows = cooltools.snipping.make_bin_aligned_windows(
             1_000_000, ["chr1", "chr1"], [120_000_000, 160_000_000], flank_bp=2_000_000
         )
-        windows = cooltools.snipping.assign_regions(windows, regions).reset_index(
+        windows = cooltools.snipping.assign_regions(windows, view_df).reset_index(
             drop=True
         )
 
@@ -59,9 +59,9 @@ def test_ondiag_pileups_without_expected(request):
     """
     Test the snipping on matrix:
     """
-    # Read cool file and create regions out of it:
+    # Read cool file and create view_df out of it:
     clr = cooler.Cooler(op.join(request.fspath.dirname, "data/CN.mm9.1000kb.cool"))
-    regions = bioframe.read_table(
+    view_df = bioframe.read_table(
         op.join(request.fspath.dirname, "data/CN.mm9.toy_regions.bed"), schema="bed4"
     )
 
@@ -71,9 +71,9 @@ def test_ondiag_pileups_without_expected(request):
         1_000_000, ["chr1", "chr1"], [120_000_000, 160_000_000], flank_bp=2_000_000
     )
 
-    windows = cooltools.snipping.assign_regions(windows, regions).reset_index(drop=True)
+    windows = cooltools.snipping.assign_regions(windows, view_df).reset_index(drop=True)
 
-    snipper = cooltools.snipping.CoolerSnipper(clr, regions=regions)
+    snipper = cooltools.snipping.CoolerSnipper(clr, view_df=view_df)
     stack = cooltools.snipping.pileup(windows, snipper.select, snipper.snip, map=map)
 
     # Check that the size of snips is OK and there are two of them:
@@ -84,7 +84,7 @@ def test_ondiag_pileups_without_expected(request):
     windows = cooltools.snipping.make_bin_aligned_windows(
         1_000_000, ["chr1", "chr1"], [120_000_000, 160_000_000], flank_bp=2_000_000
     )
-    windows = cooltools.snipping.assign_regions(windows, regions).reset_index(drop=True)
+    windows = cooltools.snipping.assign_regions(windows, view_df).reset_index(drop=True)
 
     stack = cooltools.snipping.pileup(windows, snipper.select, snipper.snip, map=map)
 
@@ -97,10 +97,10 @@ def test_offdiag_pileups_with_expected(request):
     """
     Test the snipping on matrix:
     """
-    # Read cool file and create regions out of it:
+    # Read cool file and create view_df out of it:
     clr = cooler.Cooler(op.join(request.fspath.dirname, "data/CN.mm9.1000kb.cool"))
     exp = pd.read_table(op.join(request.fspath.dirname, "data/CN.mm9.toy_expected.tsv"))
-    regions = bioframe.read_table(
+    view_df = bioframe.read_table(
         op.join(request.fspath.dirname, "data/CN.mm9.toy_regions.bed"), schema="bed4"
     )
     for snipper_class in (
@@ -108,7 +108,7 @@ def test_offdiag_pileups_with_expected(request):
         cooltools.snipping.ExpectedSnipper,
     ):
 
-        snipper = snipper_class(clr, exp, regions=regions)
+        snipper = snipper_class(clr, exp, view_df=view_df)
 
         # I.
         # Example region with windows, two off-diagonal features from annotated genomic regions:
@@ -121,7 +121,7 @@ def test_offdiag_pileups_with_expected(request):
         windows = pd.merge(
             windows1, windows2, left_index=True, right_index=True, suffixes=("1", "2")
         )
-        windows = cooltools.snipping.assign_regions(windows, regions).reset_index(
+        windows = cooltools.snipping.assign_regions(windows, view_df).reset_index(
             drop=True
         )
 
@@ -143,7 +143,7 @@ def test_offdiag_pileups_with_expected(request):
         windows = pd.merge(
             windows1, windows2, left_index=True, right_index=True, suffixes=("1", "2")
         )
-        windows = cooltools.snipping.assign_regions(windows, regions).reset_index(
+        windows = cooltools.snipping.assign_regions(windows, view_df).reset_index(
             drop=True
         )
 
@@ -159,9 +159,9 @@ def test_offdiag_pileups_without_expected(request):
     """
     Test the snipping on matrix:
     """
-    # Read cool file and create regions out of it:
+    # Read cool file and create view_df out of it:
     clr = cooler.Cooler(op.join(request.fspath.dirname, "data/CN.mm9.1000kb.cool"))
-    regions = bioframe.read_table(
+    view_df = bioframe.read_table(
         op.join(request.fspath.dirname, "data/CN.mm9.toy_regions.bed"), schema="bed4"
     )
 
@@ -176,9 +176,9 @@ def test_offdiag_pileups_without_expected(request):
     windows = pd.merge(
         windows1, windows2, left_index=True, right_index=True, suffixes=("1", "2")
     )
-    windows = cooltools.snipping.assign_regions(windows, regions).reset_index(drop=True)
+    windows = cooltools.snipping.assign_regions(windows, view_df).reset_index(drop=True)
 
-    snipper = cooltools.snipping.CoolerSnipper(clr, regions=regions)
+    snipper = cooltools.snipping.CoolerSnipper(clr, view_df=view_df)
     stack = cooltools.snipping.pileup(windows, snipper.select, snipper.snip, map=map)
 
     # Check that the size of snips is OK and there are two of them:
@@ -195,7 +195,7 @@ def test_offdiag_pileups_without_expected(request):
     windows = pd.merge(
         windows1, windows2, left_index=True, right_index=True, suffixes=("1", "2")
     )
-    windows = cooltools.snipping.assign_regions(windows, regions).reset_index(drop=True)
+    windows = cooltools.snipping.assign_regions(windows, view_df).reset_index(drop=True)
 
     stack = cooltools.snipping.pileup(windows, snipper.select, snipper.snip, map=map)
 
@@ -204,17 +204,17 @@ def test_offdiag_pileups_without_expected(request):
     assert np.all(np.isnan(stack[:, :, 1]))
 
 
-def test_snipper_with_regions_and_expected(request):
+def test_snipper_with_view_and_expected(request):
     clr = cooler.Cooler(op.join(request.fspath.dirname, "data/CN.mm9.1000kb.cool"))
     exp = pd.read_table(op.join(request.fspath.dirname, "data/CN.mm9.toy_expected.tsv"))
-    regions = bioframe.read_table(
+    view_df = bioframe.read_table(
         op.join(request.fspath.dirname, "data/CN.mm9.toy_regions.bed"), schema="bed4"
     )
     for snipper_class in (
         cooltools.snipping.ObsExpSnipper,
         cooltools.snipping.ExpectedSnipper,
     ):
-        snipper = snipper_class(clr, exp, regions=regions)
+        snipper = snipper_class(clr, exp, view_df=view_df)
         matrix = snipper.select("foo", "foo")
         snippet = snipper.snip(
             matrix, "foo", "foo", (110_000_000, 120_000_000, 110_000_000, 120_000_000)
@@ -222,12 +222,12 @@ def test_snipper_with_regions_and_expected(request):
         assert snippet.shape is not None
 
 
-def test_cooler_snipper_with_regions(request):
+def test_cooler_snipper_with_view(request):
     clr = cooler.Cooler(op.join(request.fspath.dirname, "data/CN.mm9.1000kb.cool"))
-    regions = bioframe.read_table(
+    view_df = bioframe.read_table(
         op.join(request.fspath.dirname, "data/CN.mm9.toy_regions.bed"), schema="bed4"
     )
-    snipper = cooltools.snipping.CoolerSnipper(clr, regions=regions)
+    snipper = cooltools.snipping.CoolerSnipper(clr, view_df=view_df)
     matrix = snipper.select("foo", "foo")
     snippet = snipper.snip(
         matrix, "foo", "foo", (110_000_000, 120_000_000, 110_000_000, 120_000_000)


### PR DESCRIPTION
I left the old names in places where we need to fix the code anyway, e.g. asym expected