### PR TITLE
Updated cooler_cis_eig to use make_viewframe, and added optional adaptive_coarsegrain 

### DIFF
--- a/cooltools/eigdecomp.py
+++ b/cooltools/eigdecomp.py
@@ -297,6 +297,7 @@ def cooler_cis_eig(
     bad_bins=None,
     clip_percentile=99.9,
     sort_metric=None,
+    smooth=False,
     map=map,
 ):
     """
@@ -347,6 +348,8 @@ def cooler_cis_eig(
         translocations. In reality, however, sometimes it shows poor
         performance and may lead to reporting of non-informative eigenvectors.
         Off by default.
+    smooth : boolean, optional
+        This option lets you coarsegrain the matrix prior to calling eigendecomposition.
     map : callable, optional
         Map functor implementation.
     Returns
@@ -369,7 +372,8 @@ def cooler_cis_eig(
         raise ValueError(f'No column "{phasing_track_col}" in the bin table')
 
     # regions to dataframe
-    regions = bioframe.parse_regions(regions, clr.chromsizes)
+    # regions = bioframe.parse_regions(regions, clr.chromsizes)
+    regions = bioframe.make_viewframe(regions)
 
     # ignore diags as in cooler inless specified
     ignore_diags = (
@@ -405,7 +409,11 @@ def cooler_cis_eig(
             array of eigenvalues and an array eigenvectors
         """
         _region = region[:3] # take only (chrom, start, end)
-        A = clr.matrix(balance=balance).fetch(_region)
+
+        if smooth:
+            print("Do something")
+        else:
+            A = clr.matrix(balance=balance).fetch(_region)
 
         # filter bad_bins relevant for the _region from A
         if bad_bins is not None:

--- a/cooltools/eigdecomp.py
+++ b/cooltools/eigdecomp.py
@@ -298,6 +298,8 @@ def cooler_cis_eig(
     clip_percentile=99.9,
     sort_metric=None,
     smooth=False,
+    cutoff = 3,
+    max_levels = 8,
     map=map,
 ):
     """
@@ -350,6 +352,10 @@ def cooler_cis_eig(
         Off by default.
     smooth : boolean, optional
         This option lets you coarsegrain the matrix prior to calling eigendecomposition.
+    cutoff: int, optional
+        Cutoff to pass to adaptive_coarsegrain's cutoff argument
+    max_levels: int, optional
+        Max level to pass to adaptive_coarsegrain's max_levels argument
     map : callable, optional
         Map functor implementation.
     Returns
@@ -411,7 +417,12 @@ def cooler_cis_eig(
         _region = region[:3] # take only (chrom, start, end)
 
         if smooth:
-            print("Do something")
+            A = numutils.adaptive_coarsegrain(
+                clr.matrix(balance=True).fetch(_region),
+                clr.matrix(balance=False).fetch(_region),
+                cutoff=cutoff,
+                max_levels=max_levels)
+
         else:
             A = clr.matrix(balance=balance).fetch(_region)
 


### PR DESCRIPTION
1) The most updated version of bioframe does not longer have the parse_regions function, but it works when using bioframe.make_viewframe


2) added an option to call adaptive_coarsegrain before calling eigendecomposition.
This seemed like the most suitable function to integrate it to, since adaptive_coarsegrain also requires a cooler.