### PR TITLE
Saddle refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Our contributing guide can be found [here](https://github.com/open2c/cooltools/b
 
 The following are required before installing cooltools:
 
-* Python 3.4+
+* Python 3.7+
 * `numpy`
 * `cython`
 

--- a/cooltools/cli/compute_saddle.py
+++ b/cooltools/cli/compute_saddle.py
@@ -275,7 +275,7 @@ def compute_saddle(
     expected = pd.read_table(
         expected_path,
         usecols=expected_columns,
-        #index_col=expected_index,
+        # index_col=expected_index,
         dtype=expected_dtype,
         comment=None,
         verbose=verbose,
@@ -375,23 +375,26 @@ def compute_saddle(
     #############################################
 
     track = saddle.mask_bad_bins((track, track_name), (clr.bins()[:], clr_weight_name))
+    if len(range_) == 0:
+        range_ = None
 
     digitized, binedges = saddle.get_digitized(
-                                        track[['chrom','start','end',track_name]],
-                                        n_bins,
-                                        quantiles=quantiles,
-                                        range_=range_,
-                                        qrange=qrange,
-                                        digitized_suffix='.d')
+        track[["chrom", "start", "end", track_name]],
+        n_bins,
+        quantiles=quantiles,
+        range_=range_,
+        qrange=qrange,
+        digitized_suffix=".d",
+    )
     S, C = saddle.get_saddle(
         clr,
         expected,
-        digitized[['chrom','start','end',track_name+'.d']],
+        digitized[["chrom", "start", "end", track_name + ".d"]],
         contact_type,
-        view_df = view_df,
-        clr_weight_name='weight',
-        expected_value_col='balanced.avg',
-        view_name_col = 'name',
+        view_df=view_df,
+        clr_weight_name="weight",
+        expected_value_col="balanced.avg",
+        view_name_col="name",
         min_diag=min_diag,
         max_diag=max_diag,
         verbose=verbose,

--- a/cooltools/cli/logbin_expected.py
+++ b/cooltools/cli/logbin_expected.py
@@ -180,7 +180,7 @@ def logbin_expected(
         na_rep="nan",
     )
     lb_slopes_agg.to_csv(
-        f'{output_prefix}.der.tsv',
+        f"{output_prefix}.der.tsv",
         sep="\t",
         index=False,
         na_rep="nan",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-bioframe>=0.2.0
+bioframe>=0.3.0
 click>=7
 cooler>=0.8.5
 cython

--- a/tests/test_compartments_saddle.py
+++ b/tests/test_compartments_saddle.py
@@ -7,6 +7,9 @@ import pandas as pd
 from click.testing import CliRunner
 from cooltools.cli import cli
 
+import cooltools.saddle as saddle
+import pytest
+
 
 def test_compartment_cli(request, tmpdir):
     in_cool = op.join(request.fspath.dirname, "data/sin_eigs_mat.cool")
@@ -170,17 +173,94 @@ def test_trans_saddle_cli(request, tmpdir):
     assert cc > 0.9
 
 
-# def test_digitize_track(request):
-#     pass
+def test_get_digitized():
+    # np.nan and pd.NA get digitized to -1, suffix should be added
+    df = pd.DataFrame(
+        [["chr1", 0, 10, np.nan]],
+        columns=["chrom", "start", "end", "value"],
+    )
+    digitized = saddle.get_digitized(df, 10, range_=(-1, 1), digitized_suffix=".test")[
+        0
+    ]
+    assert -1 == digitized["value.test"].values
+
+    df = pd.DataFrame(
+        [["chr1", 0, 10, pd.NA]],
+        columns=["chrom", "start", "end", "value"],
+    )
+    digitized = saddle.get_digitized(df, 10, range_=(-1, 1), digitized_suffix=".test")[
+        0
+    ]
+    assert -1 == digitized["value.test"].values
+
+    n_bins = 10
+    digitized = saddle.get_digitized(df, n_bins, range_=(-1, 1))[0]
+    # the dtype of the returned column should be a categorical
+    assert type(digitized["value.d"].dtype) is pd.core.dtypes.dtypes.CategoricalDtype
+
+    # the number of categories should be equal to the number of bins +3
+    assert (n_bins + 3) == digitized["value.d"].dtype.categories.shape[0]
+
+    df = pd.DataFrame(
+        [
+            ["chr1", 0, 10, -0.5],
+            ["chr1", 10, 20, 0.5],
+        ],
+        columns=["chrom", "start", "end", "value"],
+    )
+
+    # values out of the range should be in the 0 and n+1 bins
+    digitized = saddle.get_digitized(df, n_bins, range_=(-0.1, 0.1))[0]
+    assert 0 == digitized["value.d"].values[0]
+    assert (n_bins + 1) == digitized["value.d"].values[1]
+
+    # for an input dataframe of ten elements between -1 and 1,
+    # and 5 bins, each bin should have 2 digitized values
+    # this test will need an update after input checking
+    x = saddle.get_digitized(
+        pd.DataFrame(
+            (np.linspace(-1, 1, 10) * np.ones((4,))[:, None]).T,
+            columns=["chrom", "start", "end", "value"],
+        ),
+        5,
+        range_=(-1, 1.001),
+    )[0]["value.d"]
+    assert (2 == np.histogram(x, np.arange(1, 7))[0]).all()
+
+    # if the bottom and top quantiles are 25 and 75 with 3 bins, then
+    # the low outlier and high outlier bins should each have 3 values
+    x = saddle.get_digitized(
+        pd.DataFrame(
+            (np.linspace(-1, 1, 10) * np.ones((4,))[:, None]).T,
+            columns=["chrom", "start", "end", "value"],
+        ),
+        1,
+        qrange=(0.25, 0.75),
+    )[0]["value.d"]
+    assert 3 == np.sum(x == 0)
+    assert 3 == np.sum(x == 2)
 
 
-# def test_make_saddle(request):
-#     pass
+def test_get_saddle(request):
 
+    import cooler
 
-# def test_saddleplot(request):
-#     pass
+    clr = cooler.Cooler(op.join(request.fspath.dirname, "data/sin_eigs_mat.cool"))
 
+    track = pd.read_csv(
+        op.join(request.fspath.dirname, "test.eigs.cis.vecs.tsv"), sep="\t"
+    )[["chrom", "start", "end", "E1"]]
 
-# def test_saddlestrength(request):
-#     pass
+    expected = pd.read_csv(op.join(request.fspath.dirname, "test.expected"), sep="\t")
+
+    # non-digitized track should raise an error
+    with pytest.raises(ValueError):
+        saddle.get_saddle(clr, expected, track, "cis")
+
+    # contact_type that is not cis or trans should raise an error
+    with pytest.raises(ValueError):
+        saddle.get_saddle(clr, expected, track, "unknown")
+
+    # TODO: tests after adding input agreement, e.g.
+    # asserting saddle.get_saddle(clr, cis-type-expected, track, "trans")
+    # throws an error


### PR DESCRIPTION
updates & refactoring & tests for `cooltools.saddle` with https://github.com/open2c/cooltools/issues/258 in mind. 

- `get_saddle()` replaces `make_saddle`, and directly accepts (clr, expected, digitized_track), which will clarify the API.
- obs/expected fetchers are now underscored and understood as helper functions for `get_saddle`.
- `get_digitized` returns a dataframe and binedges instead of a histogram, and merges in what had previously been used in the CLI for bin creation. 
- digitized track is now a **categorical**

 in the end, I decided that two separate functions for cis vs trans wasn't 100% necessary, and that it wouldn't be overly cumbersome to have the digitized track as a requirement for get_saddle, since it now contains the bin information in its categories.


