### PR TITLE
Speedup expected

### DIFF
--- a/cooltools/cli/compute_expected.py
+++ b/cooltools/cli/compute_expected.py
@@ -179,13 +179,11 @@ def compute_expected(
                 map=map_,
             )
         elif contact_type == "trans":
-            # prepare pairwise combinations of regions for trans-expected (blocksum):
-            regions_pairwise = combinations(view_df.itertuples(index=False), 2)
-            regions1, regions2 = zip(*regions_pairwise)
-            result = expected.blocksum_asymm(
+            # trans-expected is calculated on an assymetric pairwise combinations
+            # of regions in view_df (special-case for faster calculations):
+            result = expected.blocksum_pairwise(
                 clr,
-                regions1=regions1,
-                regions2=regions2,
+                view_df=view_df,
                 transforms=transforms,
                 weight_name=weight_name,
                 bad_bins=None,

--- a/cooltools/cli/compute_expected.py
+++ b/cooltools/cli/compute_expected.py
@@ -9,11 +9,6 @@ import click
 from . import cli
 from . import util
 
-# might be relevant to us ...
-# https://stackoverflow.com/questions/46577535/how-can-i-run-a-dask-distributed-local-cluster-from-the-command-line
-# http://distributed.readthedocs.io/en/latest/setup.html#using-the-command-line
-
-
 @cli.command()
 @click.argument("cool_path", metavar="COOL_PATH", type=str, nargs=1)
 @click.option(
@@ -40,13 +35,6 @@ from . import util
     required=False,
 )
 @click.option(
-    "--hdf",
-    help="Use hdf5 format instead of tsv."
-    " Output file name must be specified [Not Implemented].",
-    is_flag=True,
-    default=False,
-)
-@click.option(
     "--contact-type",
     "-t",
     help="compute expected for cis or trans region of a Hi-C map."
@@ -58,10 +46,12 @@ from . import util
 @click.option(
     "--view",
     "--regions",
-    help="Path to a BED file containing genomic regions "
-    "for which expected will be calculated. Region names can "
-    "be provided in a 4th column, otherwise UCSC notaion is used."
-    "When not specified, expected is calculated for all chromosomes."
+    help="Path to a 3 or 4-column BED file containing genomic regions"
+    " for which expected will be calculated. Region names are stored"
+    " optionally in a 4th column, otherwise UCSC notaion is generated."
+    " When not specified, expected is calculated for all chromosomes."
+    " Trans-expected is calculated for all pairwise combinations of regions,"
+    " provided regions have to be sorted."
     " Note that '--regions' is the deprecated name of the option. Use '--view' instead. ",
     type=click.Path(exists=True),
     required=False,
@@ -75,19 +65,11 @@ from . import util
     show_default=True,
 )
 @click.option(
-    "--weight-name",
-    help="Use balancing weight with this name.",
+    "--clr-weight-name",
+    help="Use balancing weight with this name stored in cooler.",
     type=str,
     default="weight",
     show_default=True,
-)
-@click.option(
-    "--blacklist",
-    help="Path to a 3-column BED file containing genomic regions to mask "
-    "out during calculation of expected. Overwrites inference of "
-    "'bad' regions from balancing weights. [Not Implemented]",
-    type=click.Path(exists=True),
-    required=False,
 )
 @click.option(
     "--ignore-diags",
@@ -101,12 +83,10 @@ def compute_expected(
     nproc,
     chunksize,
     output,
-    hdf,
     contact_type,
     view,
     balance,
-    weight_name,
-    blacklist,
+    clr_weight_name,
     ignore_diags,
 ):
     """
@@ -119,13 +99,6 @@ def compute_expected(
     COOL_PATH : The paths to a .cool file with a balanced Hi-C map.
 
     """
-    if blacklist is not None:
-        raise NotImplementedError(
-            "Custom genomic regions for masking from calculation of expected"
-            "are not implemented."
-        )
-        # use blacklist-ing from cooler balance module
-        # https://github.com/mirnylab/cooler/blob/843dadca5ef58e3b794dbaf23430082c9a634532/cooler/cli/balance.py#L175
 
     clr = cooler.Cooler(cool_path)
     if view is None:
@@ -150,12 +123,12 @@ def compute_expected(
 
     # define transofrms - balanced and raw ('count') for now
     if balance:
-        weight1 = weight_name + "1"
-        weight2 = weight_name + "2"
+        weight1 = clr_weight_name + "1"
+        weight2 = clr_weight_name + "2"
         transforms = {"balanced": lambda p: p["count"] * p[weight1] * p[weight2]}
     else:
         # no masking bad bins of any kind, when balancing is not applied
-        weight_name = None
+        clr_weight_name = None
         transforms = {}
 
     # execution details
@@ -172,7 +145,7 @@ def compute_expected(
                 clr,
                 view_df,
                 transforms=transforms,
-                weight_name=weight_name,
+                weight_name=clr_weight_name,
                 bad_bins=None,
                 chunksize=chunksize,
                 ignore_diags=ignore_diags,
@@ -185,7 +158,7 @@ def compute_expected(
                 clr,
                 view_df=view_df,
                 transforms=transforms,
-                weight_name=weight_name,
+                weight_name=clr_weight_name,
                 bad_bins=None,
                 chunksize=chunksize,
                 map=map_,
@@ -205,10 +178,3 @@ def compute_expected(
     # or print into stdout otherwise:
     else:
         print(result.to_csv(sep="\t", index=False, na_rep="nan"))
-
-    # would be nice to have some binary output to preserve precision.
-    # to_hdf/read_hdf should work in this case as the file is small .
-    # still debated as to how should we store it - store in cooler seems
-    # to be consensus:
-    if hdf:
-        raise NotImplementedError("hdf output is to be implemented")

--- a/tests/test_expected.py
+++ b/tests/test_expected.py
@@ -82,7 +82,7 @@ chunksize = 10_000  # keep it small to engage chunking
 weight1 = weight_name + "1"
 weight2 = weight_name + "2"
 transforms = {"balanced": lambda p: p["count"] * p[weight1] * p[weight2]}
-
+assumed_binsize = 1_000_000
 
 chromsizes = bioframe.fetch_chromsizes("mm9")
 chromosomes = list(chromsizes.index)
@@ -94,6 +94,8 @@ common_regions = []
 for i in range(4):
     chrom = chromosomes[i]
     halfway_chrom = int(chromsizes[chrom] / 2)
+    # make halfway_chrom point "bin-aligned" according to anticipated binsize
+    halfway_chrom = round(halfway_chrom / assumed_binsize) * assumed_binsize
     reg1 = (chrom, 0, halfway_chrom)
     reg2 = (chrom, halfway_chrom, chromsizes[chrom])
     common_regions.append(reg1)

--- a/tests/test_expected.py
+++ b/tests/test_expected.py
@@ -259,7 +259,7 @@ def test_expected_cli(request, tmpdir):
         cli,
         [
             "compute-expected",
-            "--weight-name",
+            "--clr-weight-name",
             weight_name,
             "-o",
             out_cis_expected,
@@ -293,7 +293,7 @@ def test_expected_view_cli(request, tmpdir):
         cli,
         [
             "compute-expected",
-            "--weight-name",
+            "--clr-weight-name",
             weight_name,
             "--view",
             in_view,
@@ -332,7 +332,7 @@ def test_trans_expected_view_cli(request, tmpdir):
         cli,
         [
             "compute-expected",
-            "--weight-name",
+            "--clr-weight-name",
             weight_name,
             "--view",
             in_view,
@@ -379,7 +379,7 @@ def test_logbin_expected_cli(request, tmpdir):
         cli,
         [
             "compute-expected",
-            "--weight-name",
+            "--clr-weight-name",
             weight_name,
             "-o",
             out_cis_expected,

--- a/tests/test_expected.py
+++ b/tests/test_expected.py
@@ -191,6 +191,7 @@ def test_diagsum_asymm(request):
             equal_nan=True,
         )
 
+
 def test_blocksum_pairwise(request):
     # perform test:
     clr = cooler.Cooler(op.join(request.fspath.dirname, "data/CN.mm9.1000kb.cool"))
@@ -216,6 +217,7 @@ def test_blocksum_pairwise(request):
             # atol=0,
             equal_nan=True,
         )
+
 
 def test_blocksum(request):
     # perform test:


### PR DESCRIPTION
 - reintroduced efficient diagsum_symm and blocksum_pairwise (with new bioframe checks it's so easy validate regions!)
 - cleaned up compute_expected CLI and updated in accordance with new API
 - modified tests to have bin-aligned regions - it is not fair otherwise

Observations 
 - old `assign_supports` is much faster than anything `bioframe.overlap`-based, as it is just logical comparisons on 6 columns in a `pixels` tables . Can be further speed up operating directly on `bin1_id, bin2_id` and `np.searchsorted`
 
Questions:
 - do we need an efficient `diagsum_pairwise` or `diagsum_interleaved` e.g. for inter-arm , and other inter-region intra-chromosomal expected ?
 - should `blocksum_pairwise` return only inter-chromosomal results or *all* of the results (e.g. inter-arm average if arms were provided as `view_df`)?