### PR TITLE
fix-test_expected-after-bioframe-make_viewframe-name_style-update

### DIFF
--- a/cooltools/api/eigdecomp.py
+++ b/cooltools/api/eigdecomp.py
@@ -471,9 +471,9 @@ def eigs_cis(
     # output table eigvec_table and eigvals_table
     for _region, _eigvals, _eigvecs in results:
         idx = bioframe.select(eigvec_table, _region).index
-        eigvec_table.at[idx, eigvec_columns] = _eigvecs.T
+        eigvec_table.loc[idx, eigvec_columns] = _eigvecs.T
         idx = bioframe.select(eigvals_table, _region).index
-        eigvals_table.at[idx, eigval_columns] = _eigvals
+        eigvals_table.loc[idx, eigval_columns] = _eigvals
 
     return eigvals_table, eigvec_table
 

--- a/cooltools/sandbox/expected_smoothing.py
+++ b/cooltools/sandbox/expected_smoothing.py
@@ -214,7 +214,7 @@ def _agg_smooth_cvd(
     cvd, groupby, sigma_log10, window_sigma, points_per_sigma, cols=None
 ):
     if groupby:
-        cvd = cvd.groupby(groupby).apply(
+        cvd = cvd.set_index(groupby).groupby(groupby).apply(
             _smooth_cvd_group,
             sigma_log10=sigma_log10,
             window_sigma=window_sigma,

--- a/tests/test_expected.py
+++ b/tests/test_expected.py
@@ -107,7 +107,7 @@ for i in range(4):
     common_regions.append(reg1)
     common_regions.append(reg2)
 
-view_df = bioframe.make_viewframe(common_regions)
+view_df = bioframe.make_viewframe(common_regions, name_style='ucsc')
 
 
 def test_diagsum_symm(request):


### PR DESCRIPTION
changing the default behavior of bioframe.make_viewframe to not create UCSC names made the following code incompatible:
```python
common_regions = []
for i in range(4):
    chrom = chromosomes[i]
    halfway_chrom = int(chromsizes[chrom] / 2)
    # make halfway_chrom point "bin-aligned" according to anticipated binsize
    halfway_chrom = round(halfway_chrom / assumed_binsize) * assumed_binsize
    reg1 = (chrom, 0, halfway_chrom)
    reg2 = (chrom, halfway_chrom, chromsizes[chrom])
    common_regions.append(reg1)
    common_regions.append(reg2)

view_df = bioframe.make_viewframe(common_regions)
```

fixed by passing `name_style="ucsc"`