### PR TITLE
read_expected_from_file set dtypes

### DIFF
--- a/cooltools/lib/io.py
+++ b/cooltools/lib/io.py
@@ -289,6 +289,8 @@ def read_expected_from_file(
     Expected must conform v1.0 format
     https://github.com/open2c/cooltools/issues/217
 
+    dtypes are from https://github.com/open2c/cooltools/blob/master/cooltools/lib/schemas.py
+
     Parameters
     ----------
     fname : str
@@ -311,8 +313,17 @@ def read_expected_from_file(
         DataFrame with the expected
     """
 
+    if contact_type == "cis":
+        expected_dtypes = copy(schemas.diag_expected_dtypes)  # mutable copy
+    elif contact_type == "trans":
+        expected_dtypes = copy(schemas.block_expected_dtypes)  # mutable copy
+    else:
+        raise ValueError(
+            f"Incorrect contact_type: {contact_type}, only cis and trans are supported."
+        )
+
     try:
-        expected_df = pd.read_table(fname)
+        expected_df = pd.read_table(fname, dtype=expected_dtypes)
         _ = is_valid_expected(
             expected_df,
             contact_type,

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -73,18 +73,7 @@ def test_is_valid_expected(request, tmpdir):
             raise_errors=True,
         )
 
-    # alternate method of loading (read_expected_from_file):
-    expected_df_wrongdtype = expected_df.copy()
-    expected_df_wrongdtype[expected_df_wrongdtype.n_valid[0]] = "string"
-    expected_df_wrongdtype.to_csv(op.join(tmpdir, "CN.mm9.toy_expected_wrongdtype.tsv"), 
-                                  sep="\t", index=False)
-    
-    # raise error with string in one row of "n_valid" column (supposed to be Int64 dtype)
-    with pytest.raises(ValueError):
-        cooltools.lib.io.read_expected_from_file(
-            op.join(tmpdir, "CN.mm9.toy_expected_wrongdtype.tsv"),
-        )
-        
+    # alternate method of loading:
     expected_df = cooltools.lib.read_expected_from_file(
         expected_file, expected_value_cols=["balanced.avg"]
     )

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -73,7 +73,18 @@ def test_is_valid_expected(request, tmpdir):
             raise_errors=True,
         )
 
-    # alternate method of loading:
+    # alternate method of loading (read_expected_from_file):
+    expected_df_wrongdtype = expected_df.copy()
+    expected_df_wrongdtype[expected_df_wrongdtype.n_valid[0]] = "string"
+    expected_df_wrongdtype.to_csv(op.join(tmpdir, "CN.mm9.toy_expected_wrongdtype.tsv"), 
+                                  sep="\t", index=False)
+    
+    # raise error with string in one row of "n_valid" column (supposed to be Int64 dtype)
+    with pytest.raises(ValueError):
+        cooltools.lib.io.read_expected_from_file(
+            op.join(tmpdir, "CN.mm9.toy_expected_wrongdtype.tsv"),
+        )
+        
     expected_df = cooltools.lib.read_expected_from_file(
         expected_file, expected_value_cols=["balanced.avg"]
     )

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,0 +1,39 @@
+import os.path as op
+import pandas as pd
+from cooltools.lib.io import read_expected_from_file
+from cooltools.lib import is_valid_expected
+import pytest
+
+
+def test_read_expected_from_file(request, tmpdir):
+
+    expected_file = op.join(request.fspath.dirname, "data/CN.mm9.toy_expected.chromnamed.tsv")
+    expected_df = read_expected_from_file(expected_file, expected_value_cols=["balanced.avg"])
+
+    assert is_valid_expected(
+        expected_df, "cis", expected_value_cols=["balanced.avg"]
+    )
+
+    # test for error when string in one row of "n_valid" column (supposed to be Int64 dtype):
+    expected_df_wrongdtype = expected_df.copy()
+    expected_df_wrongdtype["n_valid"] = expected_df_wrongdtype["n_valid"].astype(str)
+    expected_df_wrongdtype.loc[0,"n_valid"] = "string"
+    expected_df_wrongdtype.to_csv(op.join(tmpdir, "CN.mm9.toy_expected_wrongdtype.tsv"), 
+                                  sep="\t", index=False)
+    with pytest.raises(ValueError):
+        read_expected_from_file(
+            op.join(tmpdir, "CN.mm9.toy_expected_wrongdtype.tsv"),
+            expected_value_cols=["balanced.avg"],
+        )
+
+    # test that read_expected from file works if chroms are mix of str and int
+    expected_df_intchr = expected_df.copy()
+    expected_df_intchr["region1"] = expected_df_intchr["region1"].str.replace('chr1','1')
+    expected_df_intchr["region2"] = expected_df_intchr["region2"].str.replace('chr1','1')
+    expected_df_intchr.to_csv(op.join(tmpdir, "CN.mm9.toy_expected_intchr.tsv"), 
+                                  sep="\t", index=False)
+    expected_df_intchr = read_expected_from_file(op.join(tmpdir, "CN.mm9.toy_expected_intchr.tsv"),
+                                                 expected_value_cols=["balanced.avg"])
+    assert is_valid_expected(
+        expected_df_intchr, "cis", expected_value_cols=["balanced.avg"]
+    )


### PR DESCRIPTION
Addresses issues:
https://github.com/open2c/cooltools/issues/384
https://github.com/open2c/cooltools/issues/334

read_expected_from_file takes dtypes from schemas which avoids certain errors when not setting dtypes. Added test to throw error if dtype is incompatible (str->int).

Any comments welcome