### PR TITLE
Added test data for hESCs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,7 +99,7 @@ ENV/
 tmp/
 
 # Downloaded data
-datasets/
+datasets/*
 !datasets/external_test_files.tsv
 tmp.npz
 .gitignore

--- a/datasets/external_test_files.tsv
+++ b/datasets/external_test_files.tsv
@@ -2,3 +2,4 @@
 HFF_MicroC	test.mcool	e4a0fc25c8dc3d38e9065fd74c565dd1	https://osf.io/3h9js/download	Micro-C data from HFF human cells for two chromosomes (hg38) in a multi-resolution mcool format.
 HFF_CTCF_fc	test_CTCF.bigWig	62429de974b5b4a379578cc85adc65a3	https://osf.io/w92u3/download	ChIP-Seq fold change over input with CTCF antibodies in HFF cells (hg38). Downloaded from ENCODE ENCSR000DWQ, ENCFF761RHS.bigWig file
 HFF_CTCF_binding	test_CTCF.bed.gz	61ecfdfa821571a8e0ea362e8fd48f63	https://osf.io/c9pwe/download	Binding sites called from CTCF ChIP-Seq peaks for HFF cells (hg38). Peaks are from ENCODE ENCSR000DWQ, ENCFF498QCT.bed file. The motifs are called with gimmemotifs (options --nreport 1 --cutoff 0), with JASPAR pwm MA0139.
+hESC_MicroC	test_hESC.mcool	ac0e636605505fb76fac25fa08784d5b	https://osf.io/3kdyj/download	Micro-C data fromhuman ES cells for two chromosomes (hg38) in a multi-resolution mcool format.

--- a/datasets/external_test_files.tsv
+++ b/datasets/external_test_files.tsv
@@ -2,4 +2,4 @@
 HFF_MicroC	test.mcool	e4a0fc25c8dc3d38e9065fd74c565dd1	https://osf.io/3h9js/download	Micro-C data from HFF human cells for two chromosomes (hg38) in a multi-resolution mcool format.
 HFF_CTCF_fc	test_CTCF.bigWig	62429de974b5b4a379578cc85adc65a3	https://osf.io/w92u3/download	ChIP-Seq fold change over input with CTCF antibodies in HFF cells (hg38). Downloaded from ENCODE ENCSR000DWQ, ENCFF761RHS.bigWig file
 HFF_CTCF_binding	test_CTCF.bed.gz	61ecfdfa821571a8e0ea362e8fd48f63	https://osf.io/c9pwe/download	Binding sites called from CTCF ChIP-Seq peaks for HFF cells (hg38). Peaks are from ENCODE ENCSR000DWQ, ENCFF498QCT.bed file. The motifs are called with gimmemotifs (options --nreport 1 --cutoff 0), with JASPAR pwm MA0139.
-hESC_MicroC	test_hESC.mcool	ac0e636605505fb76fac25fa08784d5b	https://osf.io/3kdyj/download	Micro-C data fromhuman ES cells for two chromosomes (hg38) in a multi-resolution mcool format.
+hESC_MicroC	test_hESC.mcool	ac0e636605505fb76fac25fa08784d5b	https://osf.io/3kdyj/download	Micro-C data from human ES cells for two chromosomes (hg38) in a multi-resolution mcool format.


### PR DESCRIPTION
Added an mcooler with chr2 and chr17 for hESCs, it's uploaded to OSF and should be available with standard cooltools test data download functions.