### PR TITLE
Record and restore nans when transposing the stack in pileups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,5 @@ tmp.npz
 .gitignore
 tmp.hdf5
 cooltools/sandbox/test.mcool
+
+.vscode

--- a/cooltools/api/snipping.py
+++ b/cooltools/api/snipping.py
@@ -985,8 +985,11 @@ def pileup(
         mymap = map
     stack = _pileup(features_df, snipper.select, snipper.snip, map=mymap)
     if feature_type == "bed":
+        nans = np.isnan(stack)
+        nans_t = np.transpose(nans, axes=(1, 0, 2))
         stack = np.nansum([stack, np.transpose(stack, axes=(1, 0, 2))], axis=0)
-
+        stack[nans] = np.nan
+        stack[nans_t] = np.nan
     if nproc > 1:
         pool.close()
     return stack


### PR DESCRIPTION
Fix https://github.com/open2c/cooltools/issues/406