### PR TITLE
chore: add pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "cython", "numpy"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Adds a `pyproject.toml`, specifying a `build-system` that includes dependencies required to run `setup.py` (`Cython` & `numpy`).

Ran into a situation like #138 a couple of times installing `cooltools` in a fresh environment. This should prevent these errors. 

You can test in a clean environment:

```sh
conda create --name cooltools python=3.10
conda activate cooltools
pip install -e .
```
