### PR TITLE
Symmetrize on-diagonal pileups correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,5 @@ tmp.npz
 .gitignore
 tmp.hdf5
 cooltools/sandbox/test.mcool
+
+.vscode/

--- a/cooltools/api/snipping.py
+++ b/cooltools/api/snipping.py
@@ -985,7 +985,7 @@ def pileup(
         mymap = map
     stack = _pileup(features_df, snipper.select, snipper.snip, map=mymap)
     if feature_type == "bed":
-        stack = np.fmax(stack, np.transpose(stack, axes=(0, 2, 1)))
+        stack = np.maximum(stack, np.transpose(stack, axes=(0, 2, 1)))
 
     if nproc > 1:
         pool.close()

--- a/cooltools/api/snipping.py
+++ b/cooltools/api/snipping.py
@@ -193,7 +193,7 @@ def _extract_stack(data_select, data_snip, arg):
             hi = feature_group["hi"].values
             s = (hi - lo).astype(int)  # Shape of individual snips
             assert s.max() == s.min(), "Pileup accepts only windows of the same size"
-            stack = np.full((s[0], s[0], len(feature_group)), np.nan)
+            stack = np.full((len(feature_group), s[0], s[0]), np.nan)
         else:  # off-diagonal off-region case:
             lo1 = feature_group["lo1"].values
             hi1 = feature_group["hi1"].values
@@ -203,8 +203,7 @@ def _extract_stack(data_select, data_snip, arg):
             s2 = (hi2 - lo2).astype(int)
             assert s1.max() == s1.min(), "Pileup accepts only windows of the same size"
             assert s2.max() == s2.min(), "Pileup accepts only windows of the same size"
-            stack = np.full((s1[0], s2[0], len(feature_group)), np.nan)
-
+            stack = np.full((len(feature_group), s1[0], s2[0]), np.nan)
         return stack, feature_group["_rank"].values
 
     # check if support region is on- or off-diagonal
@@ -226,8 +225,8 @@ def _extract_stack(data_select, data_snip, arg):
 
     data = data_select(region1, region2)
     stack = list(map(partial(data_snip, data, region1, region2), zip(s1, e1, s2, e2)))
-
-    return np.dstack(stack), feature_group["_rank"].values
+    stack = np.stack(stack)
+    return stack, feature_group["_rank"].values
 
 
 def _pileup(features, data_select, data_snip, map=map):
@@ -279,13 +278,12 @@ def _pileup(features, data_select, data_snip, map=map):
             features.groupby("region", sort=False),
         )
     )
-
     # Restore the original rank of the input features
-    cumul_stack = np.dstack(cumul_stack)
+    cumul_stack = np.concatenate(cumul_stack, axis=0)
     orig_rank = np.concatenate(orig_rank)
 
     idx = np.argsort(orig_rank)
-    cumul_stack = cumul_stack[:, :, idx]
+    cumul_stack = cumul_stack[idx, :, :]
     return cumul_stack
 
 
@@ -985,7 +983,7 @@ def pileup(
         mymap = map
     stack = _pileup(features_df, snipper.select, snipper.snip, map=mymap)
     if feature_type == "bed":
-        stack = np.fmax(stack, np.transpose(stack, axes=(1, 0, 2)))
+        stack = np.fmax(stack, np.transpose(stack, axes=(0, 2, 1)))
 
     if nproc > 1:
         pool.close()

--- a/cooltools/api/snipping.py
+++ b/cooltools/api/snipping.py
@@ -985,7 +985,7 @@ def pileup(
         mymap = map
     stack = _pileup(features_df, snipper.select, snipper.snip, map=mymap)
     if feature_type == "bed":
-        stack = np.maximum(stack, np.transpose(stack, axes=(0, 2, 1)))
+        stack = np.fmax(stack, np.transpose(stack, axes=(0, 2, 1)))
 
     if nproc > 1:
         pool.close()

--- a/cooltools/api/snipping.py
+++ b/cooltools/api/snipping.py
@@ -863,7 +863,9 @@ def pileup(
 
     Returns
     -------
-        np.ndarray: a stackup of all snippets corresponding to the features
+        np.ndarray: a stackup of all snippets corresponding to the features, with shape
+        (n, D, D), where n is the number of snippets and (D, D) is the shape of each
+        snippet
 
     """
 

--- a/cooltools/api/snipping.py
+++ b/cooltools/api/snipping.py
@@ -985,7 +985,7 @@ def pileup(
         mymap = map
     stack = _pileup(features_df, snipper.select, snipper.snip, map=mymap)
     if feature_type == "bed":
-        stack = np.nansum([stack, np.transpose(stack, axes=(1, 0, 2))], axis=0)
+        stack = np.fmax(stack, np.transpose(stack, axes=(1, 0, 2)))
 
     if nproc > 1:
         pool.close()

--- a/tests/test_snipping.py
+++ b/tests/test_snipping.py
@@ -107,14 +107,14 @@ def test_pileup(request):
 
     stack = cooltools.api.snipping.pileup(clr, windows, view_df=None, flank=None)
     # Check that the size of snips is OK and there are two of them:
-    assert stack.shape == (5, 5, 2)
+    assert stack.shape == (2, 5, 5)
 
     stack = cooltools.api.snipping.pileup(
         clr, windows, view_df=view_df, expected_df=exp, flank=None
     )
     # Check that the size of snips is OK and there are two of them.
     # Now with view and expected:
-    assert stack.shape == (5, 5, 2)
+    assert stack.shape == (2, 5, 5)
 
     # II.
     # Example off-diagonal features, two features from annotated genomic regions:
@@ -132,7 +132,7 @@ def test_pileup(request):
         clr, windows, view_df=view_df, expected_df=exp, flank=None
     )
     # Check that the size of snips is OK and there are two of them:
-    assert stack.shape == (5, 5, 2)
+    assert stack.shape == (2, 5, 5)
 
     # III.
     # Example off-diagonal features, one region outside the view:
@@ -150,9 +150,9 @@ def test_pileup(request):
         clr, windows, view_df=view_df, expected_df=exp, flank=None
     )
     # Check that the size of snips is OK and there are two of them:
-    assert stack.shape == (5, 5, 2)
+    assert stack.shape == (2, 5, 5)
 
-    assert np.all(np.isnan(stack[:, :, 0]))
+    assert np.all(np.isnan(stack[0]))
 
     # IV.
     # Example on-diagonal features, not valid bedframes (start>end):
@@ -169,7 +169,7 @@ def test_pileup(request):
     # DRAFT # Should work with force=True:
     # stack = cooltools.api.snipping.pileup(clr, windows, view_df, exp, flank=None, force=True)
     # # Check that the size of snips is OK and there are two of them:
-    # assert stack.shape == (5, 5, 2)
+    # assert stack.shape == (2, 5, 5,)
 
     # IV.
     # Example of-diagonal features not valid bedframes (start>end):
@@ -191,7 +191,7 @@ def test_pileup(request):
     # DRAFT # Should work with force=True:
     # stack = cooltools.api.snipping.pileup(clr, windows, view_df, exp, flank=0, force=True)
     # # Check that the size of snips is OK and there are two of them:
-    # assert stack.shape == (5, 5, 2)
+    # assert stack.shape == (2, 5, 5,)
 
 
 def test_ondiag__pileup_with_expected(request):
@@ -223,7 +223,7 @@ def test_ondiag__pileup_with_expected(request):
         )
 
         # Check that the size of snips is OK and there are two of them:
-        assert stack.shape == (5, 5, 2)
+        assert stack.shape == (2, 5, 5)
 
         # II.
         # Example region with windows, second window comes from unannotated genomic region:
@@ -238,8 +238,8 @@ def test_ondiag__pileup_with_expected(request):
             windows, snipper.select, snipper.snip, map=map
         )
 
-        assert stack.shape == (5, 5, 2)
-        assert np.all(np.isnan(stack[:, :, 1]))
+        assert stack.shape == (2, 5, 5)
+        assert np.all(np.isnan(stack[1]))
 
 
 def test_ondiag__pileup_without_expected(request):
@@ -267,7 +267,7 @@ def test_ondiag__pileup_without_expected(request):
     )
 
     # Check that the size of snips is OK and there are two of them:
-    assert stack.shape == (5, 5, 2)
+    assert stack.shape == (2, 5, 5)
 
     # II.
     # Example region with windows, second window comes from unannotated genomic region:
@@ -282,9 +282,9 @@ def test_ondiag__pileup_without_expected(request):
         windows, snipper.select, snipper.snip, map=map
     )
 
-    assert stack.shape == (5, 5, 2)
-    assert np.all(np.isfinite(stack[:, :, 0]))
-    assert np.all(np.isnan(stack[:, :, 1]))
+    assert stack.shape == (2, 5, 5)
+    assert np.all(np.isfinite(stack[0]))
+    assert np.all(np.isnan(stack[1]))
 
 
 def test_offdiag__pileup_with_expected(request):
@@ -324,7 +324,7 @@ def test_offdiag__pileup_with_expected(request):
         )
 
         # Check that the size of snips is OK and there are two of them:
-        assert stack.shape == (5, 5, 2)
+        assert stack.shape == (2, 5, 5)
 
         # II.
         # Example region with windows, second window is between two different regions:
@@ -345,8 +345,8 @@ def test_offdiag__pileup_with_expected(request):
             windows, snipper.select, snipper.snip, map=map
         )
 
-        assert stack.shape == (5, 5, 2)
-        assert np.all(np.isnan(stack[:, :, 1]))
+        assert stack.shape == (2, 5, 5)
+        assert np.all(np.isnan(stack[1]))
 
 
 def test_offdiag__pileup_without_expected(request):
@@ -380,7 +380,7 @@ def test_offdiag__pileup_without_expected(request):
     )
 
     # Check that the size of snips is OK and there are two of them:
-    assert stack.shape == (5, 5, 2)
+    assert stack.shape == (2, 5, 5)
 
     # II.
     # Example region with windows, second window comes from unannotated genomic region:
@@ -401,9 +401,9 @@ def test_offdiag__pileup_without_expected(request):
         windows, snipper.select, snipper.snip, map=map
     )
 
-    assert stack.shape == (5, 5, 2)
-    assert np.all(np.isfinite(stack[:, :, 0]))
-    assert np.all(np.isnan(stack[:, :, 1]))
+    assert stack.shape == (2, 5, 5)
+    assert np.all(np.isfinite(stack[0]))
+    assert np.all(np.isnan(stack[1]))
 
 
 def test_snipper_with_view_and_expected(request):

--- a/tests/test_snipping.py
+++ b/tests/test_snipping.py
@@ -110,6 +110,7 @@ def test_pileup(request):
     assert stack.shape == (2, 5, 5)
     # Check that NaNs were propagated
     assert np.all(np.isnan(stack[0, 2, :]))
+    assert not np.all(np.isnan(stack))
 
     stack = cooltools.api.snipping.pileup(
         clr, windows, view_df=view_df, expected_df=exp, flank=None

--- a/tests/test_snipping.py
+++ b/tests/test_snipping.py
@@ -100,14 +100,16 @@ def test_pileup(request):
     windows = pd.DataFrame(
         {
             "chrom": ["chr1", "chr1"],
-            "start": [102_000_000, 108_000_000],
-            "end": [107_000_000, 113_000_000],
+            "start": [83000000, 108_000_000],
+            "end": [88_000_000, 113_000_000],
         }
     )
 
     stack = cooltools.api.snipping.pileup(clr, windows, view_df=None, flank=None)
     # Check that the size of snips is OK and there are two of them:
     assert stack.shape == (2, 5, 5)
+    # Check that NaNs were propagated
+    assert np.all(np.isnan(stack[0, 2, :]))
 
     stack = cooltools.api.snipping.pileup(
         clr, windows, view_df=view_df, expected_df=exp, flank=None


### PR DESCRIPTION
Fixes https://github.com/open2c/cooltools/issues/406
And addresses comments from https://github.com/open2c/cooltools/pull/418, and supersedes it.
(except the idea for a test for correct symmetrization... but np.fmax seems foolproof!)