### PR TITLE
Dotsfix to prevent more IndexErrors

### DIFF
--- a/cooltools/api/dotfinder.py
+++ b/cooltools/api/dotfinder.py
@@ -665,6 +665,7 @@ def get_adjusted_expected_tile_some_nans(
     # NaNs during convolution:
     O_bal[N_bal] = 0.0
     E_bal[N_bal] = 0.0
+    E_raw[N_bal] = 0.0  # todo: consider filtering those altogether
     # think about usinf copyto and where functions later:
     # https://stackoverflow.com/questions/6431973/how-to-copy-data-from-a-numpy-array-to-another
     #

--- a/cooltools/api/dotfinder.py
+++ b/cooltools/api/dotfinder.py
@@ -436,11 +436,11 @@ def tile_square_matrix(matrix_size, offset, tile_size, pad=0):
     else:
         num_tiles = matrix_size // tile_size
 
-    logging.info(
+    logging.debug(
         f" matrix {matrix_size}X{matrix_size} to be split into {num_tiles * num_tiles} tiles of {tile_size}X{tile_size}."
     )
     if pad:
-        logging.info(
+        logging.debug(
             f" tiles are padded (width={pad}) to enable convolution near the edges"
         )
 

--- a/cooltools/api/dotfinder.py
+++ b/cooltools/api/dotfinder.py
@@ -1340,8 +1340,10 @@ def scoring_and_histogramming_step(
             raise ValueError(
                 f"There are la_exp.{k}.value in {last_lambda_bin.name}, please check the histogram"
             )
-        # drop all lambda-bins that do not have pixels in them:
-        final_hist[k] = final_hist[k].loc[:, final_hist[k].sum() > 0]
+        # last non-empty lambda bin (column)
+        last_non_empty_lbin = final_hist[k].columns[final_hist[k].sum() > 0][-1]
+        # drop trailing empty lambda bins (columns)
+        final_hist[k] = final_hist[k].loc[:, :last_non_empty_lbin]
         # make sure index (observed pixels counts) is sorted
         if not final_hist[k].index.is_monotonic_increasing:
             raise ValueError(f"Histogram for {k}-kernel is not sorted")

--- a/tests/test_dotfinder_stats.py
+++ b/tests/test_dotfinder_stats.py
@@ -215,7 +215,7 @@ def test_histogramming_summary():
     # make sure total sum of the histogram yields total number of pixels:
     for k, _hist in gw_hists.items():
         assert _hist.sum().sum() == num_pixels
-        assert _hist.index.is_monotonic  # is index sorted
+        assert _hist.index.is_monotonic_increasing  # is index sorted
 
 
 # test threshold and rejection tables and only then try q-values
@@ -238,7 +238,7 @@ def test_thresholding():
     threshold_df, qvalues = determine_thresholds(gw_hists, FDR)
 
     enriched_pixels_df = extract_scored_pixels(
-        scored_df, threshold_df, obs_raw_name="count"
+        scored_df, threshold_df, ledges, obs_raw_name="count"
     )
 
     # all enriched pixels have their Null hypothesis rejected


### PR DESCRIPTION
small fixes in dotfinder to prevent IndexErrors in `extract_scored_pixels`: prevent `NaN`- valued pixel scores, consider "non-monotonous" histogram