### PR TITLE
fix 421 - allow view without names

### DIFF
--- a/cooltools/lib/io.py
+++ b/cooltools/lib/io.py
@@ -350,6 +350,9 @@ def read_viewframe_from_file(
     Read a BED file with regions that conforms
     a definition of a viewframe (non-overlaping, unique names, etc).
 
+    When the 4th column with names is missing, UCSC-style names
+    are enforced.
+
     Parameters
     ----------
     view_fname : str
@@ -380,7 +383,7 @@ def read_viewframe_from_file(
 
     # Convert view dataframe to viewframe:
     try:
-        view_df = bioframe.make_viewframe(view_df)
+        view_df = bioframe.make_viewframe(view_df, name_style="ucsc")
     except ValueError as e:
         raise ValueError(
             "View table is incorrect, please, comply with the format. "

--- a/cooltools/lib/io.py
+++ b/cooltools/lib/io.py
@@ -369,10 +369,10 @@ def read_viewframe_from_file(
 
     # read BED file assuming bed4/3 formats (with names-columns and without):
     try:
-        view_df = bioframe.read_table(view_fname, schema="bed4", index_col=False)
+        view_df = bioframe.read_table(view_fname, schema="bed4", schema_is_strict=True)
     except Exception as err_bed4:
         try:
-            view_df = bioframe.read_table(view_fname, schema="bed3", index_col=False)
+            view_df = bioframe.read_table(view_fname, schema="bed3", schema_is_strict=True)
         except Exception as err_bed3:
             raise ValueError(
                 f"{view_fname} is not a BED file with 3 or 4 columns"

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,7 +1,8 @@
 import os.path as op
 import pandas as pd
-from cooltools.lib.io import read_expected_from_file
+from cooltools.lib.io import read_expected_from_file, read_viewframe_from_file
 from cooltools.lib import is_valid_expected
+import bioframe
 import pytest
 
 
@@ -37,3 +38,18 @@ def test_read_expected_from_file(request, tmpdir):
     assert is_valid_expected(
         expected_df_intchr, "cis", expected_value_cols=["balanced.avg"]
     )
+
+
+def test_read_viewframe_from_file(request, tmpdir):
+
+    # test viewframe with 4 columns - i.e. with unique names
+    view_file_wnames = op.join(request.fspath.dirname, "data/CN.mm9.toy_regions.bed")
+    view_df = read_viewframe_from_file(view_file_wnames, verify_cooler=None, check_sorting=False)
+    assert bioframe.is_viewframe(view_df)
+
+    # test viewframe with 3 columns - i.e. without unique names
+    view_file_wonames = op.join(request.fspath.dirname, "data/CN.mm9.toy_features.bed")
+    view_df = read_viewframe_from_file(view_file_wonames, verify_cooler=None, check_sorting=False)
+    assert bioframe.is_viewframe(view_df)
+    # for a 3 column viewframe, UCSC strings should assigned to names
+    assert view_df["name"].apply(bioframe.is_complete_ucsc_string).all()


### PR DESCRIPTION
engaged `schema_is_strict=True` for reading `bed4` or `bed3` viewframe from file addressing #421

I checked and it ooks like this is the only place where we use `bioframe.read_table` so this should be ok from generality perspective 