### PR TITLE
Replaced np.int with int in adaptive_coarsegrain

### DIFF
--- a/cooltools/lib/numutils.py
+++ b/cooltools/lib/numutils.py
@@ -1315,7 +1315,7 @@ def adaptive_coarsegrain(ar, countar, cutoff=5, max_levels=8, min_shape=8):
     Norig = ar.shape[0]
     Nlog = np.log2(Norig)
     if not np.allclose(Nlog, np.rint(Nlog)):
-        newN = np.int(2 ** np.ceil(Nlog))  # next power-of-two sized matrix
+        newN = int(2 ** np.ceil(Nlog))  # next power-of-two sized matrix
         newar = np.empty((newN, newN), dtype=float)  # fitting things in there
         newar[:] = np.nan
         newcountar = np.zeros((newN, newN), dtype=float)


### PR DESCRIPTION
The adaptive_coarsegrain function doesn't work when using NumPy 1.24 and later because line [1318](https://github.com/open2c/cooltools/blob/8af2b1087f7302d282dc77a82047ac0a3a8339c1/cooltools/lib/numutils.py#L1318C1-L1319C1) in cooltools/cooltools/lib/numutils.py uses `np.int`, which was deprecated in NumPy 1.20 and fully removed in NumPy 1.24 (see [here](https://numpy.org/devdocs/release/1.20.0-notes.html)). It should be replaced by `int` or `np.int_`. 

Per the suggestion from @nvictus in issue [472](https://github.com/open2c/cooltools/issues/472), I opted for the `int` option. 