### PR TITLE
enforce multiprocess-dill

### DIFF
--- a/cooltools/api/snipping.py
+++ b/cooltools/api/snipping.py
@@ -48,7 +48,7 @@ from ..lib.common import assign_view_auto, make_cooler_view
 from ..lib.numutils import LazyToeplitz
 import warnings
 
-import multiprocessing
+from multiprocess import Pool
 
 
 def expand_align_features(features_df, flank, resolution, format="bed"):
@@ -979,7 +979,7 @@ def pileup(
         )
 
     if nproc > 1:
-        pool = multiprocessing.Pool(nproc)
+        pool = Pool(nproc)
         mymap = pool.map
     else:
         mymap = map

--- a/cooltools/cli/coverage.py
+++ b/cooltools/cli/coverage.py
@@ -6,7 +6,7 @@ from .. import coverage
 from . import cli
 from .. import api
 import bioframe
-import multiprocessing as mp
+import multiprocess as mp
 
 
 @cli.command()

--- a/cooltools/lib/common.py
+++ b/cooltools/lib/common.py
@@ -8,7 +8,7 @@ import pandas as pd
 
 import bioframe
 
-from multiprocessing import Pool
+from multiprocess import Pool
 
 
 def assign_view_paired(


### PR DESCRIPTION
[`multiprocess`](https://pypi.org/project/multiprocess/) has been used in most of the cooltools so far (and in cooler itself) - imho we should continue using it throughout
examples where `multiprocessing` fail:
 - dots simply not work with it
 - multiprocessing prevents nested multiprocessiong https://github.com/open2c/open2c_examples/issues/29
 - more (?)