### PR TITLE
Update _numutils.pyx

### DIFF
--- a/cooltools/lib/_numutils.pyx
+++ b/cooltools/lib/_numutils.pyx
@@ -13,7 +13,7 @@ ctypedef unsigned short ushort
 ctypedef unsigned char uchar
 
 cdef extern from "stdlib.h":
-    long c_libc_random "random"()
+    long c_libc_random "rand"()
     double c_libc_drandom "drand48"()
 
 


### PR DESCRIPTION
Changed "random" to "rand" -- The random function was not available on MSVC's "stdlib.h" for me, and after doing some more research, I realized that "rand()" instead of "random()" might be better for more compatibility across various operating systems.