### PR TITLE
Allow upgrade pandas (version 2+) and python (up to 3.12) versions

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.8', '3.9', '3.10' ]
+        python-version: [ '3.9', '3.10', '3.12' ]
 
     steps:
     - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,4 @@ tmp.hdf5
 cooltools/sandbox/test.mcool
 
 .vscode/
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ cooltools/__pycache__
 # Distribution / packaging
 .Python
 env/
+.venv/
 build/
 develop-eggs/
 dist/

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ matplotlib
 multiprocess
 numba
 numpy
-pandas>=1.5.1,<2
+pandas>=1.5.1
 scikit-learn>=1.1.2
 scipy
 scikit-image


### PR DESCRIPTION
This PR adds cool tools support for updated pandas versions and python versions. 